### PR TITLE
Use Jellyfin login for Jellyseerr

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ KodiSeerr is a lightweight and user-friendly Kodi add-on that lets you browse, s
 - 🔍 **Search** for movies and TV shows
 - 🔥 View **Trending** and **Popular** content
 - ✅ **Request** movies or TV shows with a single click
-- 🔐 Uses your JellySeerr **username and password** (no API key required)
+- 🔐 Uses your JellySeerr (or Jellyfin) **username and password** (no API key required)
 - ☕ Easy to install and open-source
 
 ---

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.kodiseerr" name="KodiSeerr" version="2.0.1" provider-name="vaughngx4, Yock">
+<addon id="plugin.video.kodiseerr" name="KodiSeerr" version="2.1.0" provider-name="vaughngx4, Yock">
     <requires>
         <import addon="xbmc.python" version="3.0.1"/>
     </requires>

--- a/jellyseerr_api.py
+++ b/jellyseerr_api.py
@@ -15,6 +15,7 @@ class JellyseerrClient:
         self.cookie_jar = http.cookiejar.CookieJar()
         self.opener = None  # Will be initialized with SSL context
         self.logged_in = False
+        self.allowed_user_type = xbmcaddon.Addon().getSetting("allowed_user_type") or "0"
 
     def init_opener(self):
         """Initializes the opener with SSL context based on addon settings."""
@@ -31,27 +32,71 @@ class JellyseerrClient:
         self.opener = urllib.request.build_opener(https_handler, cookie_handler)
 
     def login(self):
-        """Logs into the Jellyseerr/Overseerr instance."""
+        """Logs into the Jellyseerr instance - Endpoints based on allowed user type."""
         if self.logged_in:
             return
 
         self.init_opener()
 
-        login_url = f"{self.base_url}/auth/local"
-        data = json.dumps({
-            "email": self.username,
-            "password": self.password
-        }).encode('utf-8')
+        mode = str(self.allowed_user_type)
+        # 0: local only, 1: remote only, 2: local then remote, 3: remote then local
+        if mode == "0":
+            self._login_local()
+        elif mode == "1":
+            self._login_remote()
+        elif mode == "2":
+            first = self._login_local()
+            if first is False:
+                self._login_remote()
+        elif mode == "3":
+            first = self._login_remote()
+            if first is False:
+                self._login_local()
+        else:
+            # Fallback to local only if setting is unexpected
+            self._login_local()
 
-        req = urllib.request.Request(login_url, data=data)
+    def _make_request(self, url, payload):
+        data = json.dumps(payload).encode('utf-8')
+        req = urllib.request.Request(url, data=data)
         req.add_header("Content-Type", "application/json")
-
         try:
             with self.opener.open(req) as resp:
                 resp.read()
-            self.logged_in = True
+            return True
+        except urllib.error.HTTPError as e:
+            # 401/403 should allow fallback
+            if e.code in (401, 403):
+                xbmc.log(f"[kodiseerr] Auth HTTP error {e.code} for {url}", xbmc.LOGWARNING)
+                return False
+            xbmc.log(f"[kodiseerr] Auth failed HTTP {e.code} for {url}", xbmc.LOGERROR)
+            # Non-fallback eligible error
+            return None
         except urllib.error.URLError as e:
-            xbmc.log(f"[kodiseerr] Login failed: {e}", xbmc.LOGERROR)
+            xbmc.log(f"[kodiseerr] Auth network error for {url}: {e}", xbmc.LOGWARNING)
+            return False
+
+    def _login_local(self):
+        login_url = f"{self.base_url}/auth/local"
+        payload = {
+            "email": self.username,
+            "password": self.password,
+        }
+        result = self._make_request(login_url, payload)
+        if result is True:
+            self.logged_in = True
+        return result
+
+    def _login_remote(self):
+        login_url = f"{self.base_url}/auth/jellyfin"
+        payload = {
+            "username": self.username,
+            "password": self.password,
+        }
+        result = self._make_request(login_url, payload)
+        if result is True:
+            self.logged_in = True
+        return result
 
     def api_request(self, endpoint, method="GET", data=None, params=None):
         """Sends an authenticated API request to the server."""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,6 +5,7 @@
         <setting id="allow_self_signed" type="bool" label="Allow self-signed certificates" default="false" />
         <setting id="jellyseerr_username" type="text" label="Username" default="" />
         <setting id="jellyseerr_password" type="text" option="hidden" label="Password" default="" />
+        <setting id="allowed_user_type" type="enum" label="Allowed user type" values="Jellyseerr user (local user)|Jellyfin user (remote user)|Jellyseerr user (local user) then Jellyfin user (remote user)|Jellyfin user (remote user) then Jellyseerr user (local user)" default="0" visible="eq(-5,0)" />
         <setting id="enable_ask_4k" type="bool" label="Enable asking for 4K" default="true" />
         <setting id="enable_request_notifications" type="bool" label="Enable Request Notifications" default="true" />
         <setting id="polling_interval" type="number" label="Polling Interval (Seconds)" default="300" />


### PR DESCRIPTION
I login in Jellyseer using my Jellyfin account. Wasn't aware I was doing this so it took me a while before I understood why KodiSeerr couldn't connect to Jellyseerr. This change adds the same "Use Jellyfin account for Jellyseerr login" functionality to KodiSeerr.

Let me know if you think my method is too convoluted and this Jellyfin account fallback should be default and non-configurable then I'll change the implementation.

Hope you see the added value of this change!